### PR TITLE
CDN url for images

### DIFF
--- a/src/extensions/image.ts
+++ b/src/extensions/image.ts
@@ -120,7 +120,7 @@ const extension: ExtensionMeta<typeof Image> = {
       meta: {
         interface: "string",
         width: "half",
-        note: "CDN URL for image consumption",
+        note: "CDN address for HTML output (optional)",
       },
     },
   ],

--- a/src/extensions/image.ts
+++ b/src/extensions/image.ts
@@ -88,7 +88,7 @@ export const Image = Node.create<ImageOptions>({
   renderHTML({ HTMLAttributes }) {
     const id = HTMLAttributes["data-directus-id"];
     const filename = HTMLAttributes["data-directus-filename"];
-    const src = this.options.publicURL + "assets/" + id + (filename ? "/" + filename : "");
+    const src = this.options.publicURL + id + (filename ? "/" + filename : "");
     return ["img", mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, { src })];
   },
 
@@ -112,9 +112,26 @@ const extension: ExtensionMeta<typeof Image> = {
   package: "File Library",
   group: "node",
   defaults: {},
-  options: [],
-  load() {
-    return Image;
+  options: [
+    {
+      field: "cdnURL",
+      name: "CDN URL",
+      type: "string",
+      meta: {
+        interface: "string",
+        width: "half",
+        note: "CDN URL for image consumption",
+      },
+    },
+  ],
+  load(props) {
+    return Image.configure({
+      publicURL: props.cdnURL
+        ? props.cdnURL?.endsWith("/")
+          ? props.cdnURL
+          : props.cdnURL + "/"
+        : getPublicURL() + "assets/",
+    });
   },
 };
 

--- a/src/extensions/index.ts
+++ b/src/extensions/index.ts
@@ -31,6 +31,7 @@ export const extensionsGroups: { group: ExtensionGroup; label: string }[] = [
 
 interface ExtensionsProps {
   extensions: string[] | null;
+  cdnURL: string | null;
   placeholder: PlaceholderOptions["placeholder"];
   characterCountLimit: CharacterCountOptions["limit"];
   characterCountMode: CharacterCountOptions["mode"];

--- a/src/tiptap-editor.vue
+++ b/src/tiptap-editor.vue
@@ -922,6 +922,7 @@ interface Props {
   autofocus: boolean;
   extensions: string[] | null;
   // extensions options
+  cdnURL: string | null;
   placeholder: PlaceholderOptions["placeholder"];
   textAlignTypes: TextAlignOptions["types"];
   characterCountLimit: CharacterCountOptions["limit"];
@@ -936,6 +937,7 @@ const props = withDefaults(defineProps<Props>(), {
   disabled: false,
   autofocus: false,
   extensions: null,
+  cdnURL: null,
   placeholder: () => placeholder.defaults.placeholder,
   textAlignTypes: () => textAlign.defaults.types,
   characterCountLimit: () => characterCount.defaults.limit,


### PR DESCRIPTION
Hi, thanks for this extension, it's been quite useful to me.

This change allows the user to set an optional CDN url to consume the images from. I reckon it can be quite useful as it'd allow to reduce download/egress costs while rendering the HTML from tiptap inside Directus before sending the information to the client – as Directus so far hasn't added a 'download url' for CDN, similar to what rclone has for S3 storage.